### PR TITLE
fix syntax error in object literal

### DIFF
--- a/node_modules/@octokit/core/README.md
+++ b/node_modules/@octokit/core/README.md
@@ -415,8 +415,7 @@ const plugin = (octokit, options = { greeting: "Hello" }) => {
 
   // add a custom method
   return {
-    helloWorld: () => console.log(`${options.greeting}, world!`);
-  }
+    helloWorld: () => console.log(`${options.greeting}, world!`)
 };
 export default plugin;
 ```


### PR DESCRIPTION
An extra closing curly brace disrupts the structure of the object.  
A semicolon inside the object violates the syntax.

