### PR TITLE
Fix typo Update README.md

### DIFF
--- a/node_modules/@octokit/core/README.md
+++ b/node_modules/@octokit/core/README.md
@@ -384,7 +384,7 @@ A plugin is a function which gets two arguments:
 1. the current instance
 2. the options passed to the constructor.
 
-In order to extend `octokit`'s API, the plugin must return an object with the new methods. Please refrain from adding methods directly to the `octokit` instance, especialy if you depend on keys that do not exist in `@octokit/core`, such as `octokit.rest`.
+In order to extend `octokit`'s API, the plugin must return an object with the new methods. Please refrain from adding methods directly to the `octokit` instance, especially if you depend on keys that do not exist in `@octokit/core`, such as `octokit.rest`.
 
 ```js
 // index.js


### PR DESCRIPTION
# Fix Typo in README.md

This pull request corrects a typo in the `README.md` file. Specifically:
- Corrected `especialy` to `especially`.

This change improves the clarity and accuracy of the documentation.

---

### Changes:
```diff
- especialy
+ especially
