### PR TITLE
README.md

### DIFF
--- a/node_modules/@octokit/plugin-paginate-rest/README.md
+++ b/node_modules/@octokit/plugin-paginate-rest/README.md
@@ -170,7 +170,7 @@ for await (const response of octokit.paginate.iterator(
 
 ## `composePaginateRest` and `composePaginateRest.iterator`
 
-The `compose*` methods work just like their `octokit.*` counterparts described above, with the differenct that both methods require an `octokit` instance to be passed as first argument
+The `compose*` methods work just like their `octokit.*` counterparts described above, with the different that both methods require an `octokit` instance to be passed as first argument
 
 ## How it works
 


### PR DESCRIPTION
# Fix Typo in README.md

## Description
This pull request addresses a minor typographical error in the `README.md` file for `@octokit/plugin-paginate-rest`.

### Changes Made:
- Corrected "differenct" to "different" for improved clarity and professionalism.

## Checklist
- [x] Verified that the change is limited to documentation.
- [x] Ensured no other sections were affected.

---

Feel free to suggest further edits or improvements!
